### PR TITLE
updating GCP Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,13 @@
 ansible/**/*.retry
 
 # Terraform
+terraform/**/.terraform
+terraform/**/*.tfvars
 terraform/**/*.tfstate
 terraform/**/*.tfstate.backup
 terraform/**/*.tfstate.lock.info
+terraform/**/.terraform.lock.hcl
+terraform/**/providers.tf
 
 # General
 .DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.tabSize": 2
+}

--- a/terraform/gcp/bucket.tf
+++ b/terraform/gcp/bucket.tf
@@ -4,6 +4,10 @@ resource "google_storage_bucket" "gitops" {
   location      = var.bucket_location
   storage_class = var.bucket_storage_class
 
+  versioning {
+    enabled = true
+  }
+
   # WARNING: setting to true will cause TF to fail
   # when attempting to delete the bucket
   force_destroy = true

--- a/terraform/gcp/bucket.tf
+++ b/terraform/gcp/bucket.tf
@@ -1,0 +1,14 @@
+resource "google_storage_bucket" "gitops" {
+  project       = module.wireguard.project_id
+  name          = format("%s-%s", var.bucket_name, local.project_suffix)
+  location      = var.bucket_location
+  storage_class = var.bucket_storage_class
+
+  # WARNING: setting to true will cause TF to fail
+  # when attempting to delete the bucket
+  force_destroy = true
+
+  # NOTE: Uniform IAM permissions to all objects in
+  # the bucket when true
+  uniform_bucket_level_access = true
+}

--- a/terraform/gcp/firewall.tf
+++ b/terraform/gcp/firewall.tf
@@ -1,0 +1,35 @@
+# --------------------------------------------------
+# OUTBOUND: Allow
+# --------------------------------------------------
+
+# --------------------------------------------------
+# OUTBOUND: Deny
+# --------------------------------------------------
+
+# --------------------------------------------------
+# INBOUND: Allow
+# --------------------------------------------------
+resource "google_compute_firewall" "allow_iap_ssh_tag" {
+  name    = "allow-iap-ssh-tag"
+  network = module.vpn.network_self_link
+  project = module.wireguard.project_id
+
+  direction = "INGRESS"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  # https://cloud.google.com/iap/docs/using-tcp-forwarding#create-firewall-rule
+  source_ranges = ["35.235.240.0/20"]
+
+  target_tags = [
+    "iap-ssh",
+  ]
+}
+
+
+# --------------------------------------------------
+# INBOUND: Deny
+# --------------------------------------------------

--- a/terraform/gcp/gusw_instances.tf
+++ b/terraform/gcp/gusw_instances.tf
@@ -1,0 +1,61 @@
+locals {
+  gusw_distribution = {
+    "us-west1" = [
+      {
+        zone       = "us-west1-a"
+        network_ip = "10.0.0.2"
+      }
+    ]
+  }
+}
+
+module "gusw_tpl" {
+  source  = "terraform-google-modules/vm/google//modules/instance_template"
+  version = "~> 6.2"
+
+  name_prefix  = "vpn"
+  project_id   = module.wireguard.project_id
+  machine_type = var.machine_type
+  metadata     = var.metadata
+  labels       = var.instance_labels
+  tags         = var.instance_tags
+
+  /* service account */
+  service_account = {
+    email  = google_service_account.wireguard.email
+    scopes = var.service_account_scopes
+  }
+
+  /* image */
+  source_image_family  = var.boot_disk_image_family
+  source_image_project = var.boot_disk_image_project
+
+  /* disks */
+  disk_size_gb = var.boot_disk_size_gb
+  disk_type    = var.boot_disk_type
+  auto_delete  = var.boot_disk_auto_delete
+
+  /* network */
+  subnetwork         = local.vpn_links_by_name["gusw1-wg"]
+  subnetwork_project = module.wireguard.project_id
+  can_ip_forward     = var.can_ip_forward
+}
+
+resource "google_compute_instance_from_template" "gusw1_instances" {
+  provider = google
+  count    = length(local.gusw_distribution["us-west1"])
+
+  name    = "vpn-gusw1-${format("%03d", count.index + 1)}"
+  project = module.wireguard.project_id
+  zone    = local.gusw_distribution["us-west1"][count.index].zone
+
+
+  network_interface {
+    network            = module.vpn.network_self_link
+    network_ip         = local.gusw_distribution["us-west1"][count.index].network_ip
+    subnetwork         = local.vpn_links_by_name["gusw1-wg"]
+    subnetwork_project = module.wireguard.project_id
+  }
+
+  source_instance_template = module.gusw_tpl.self_link
+}

--- a/terraform/gcp/locals.tf
+++ b/terraform/gcp/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  vpn_links_by_name = zipmap(module.vpn.subnets_names, module.vpn.subnets_self_links)
+}

--- a/terraform/gcp/project.tf
+++ b/terraform/gcp/project.tf
@@ -1,0 +1,23 @@
+locals {
+  project_suffix = split(format("%s-", var.project_name), module.wireguard.project_id)[1]
+}
+
+module "wireguard" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 10.2.1"
+
+  name                    = var.project_name
+  org_id                  = var.org_id
+  billing_account         = var.billing_account
+  project_id              = var.project_id
+  random_project_id       = true
+  default_service_account = "delete"
+  labels                  = var.labels
+
+  activate_apis = [
+    "cloudbilling.googleapis.com",
+  ]
+
+  # budget_alert_spent_percents = [0.7, 0.8, 0.9, 1.0]
+  # budget_amount               = 100
+}

--- a/terraform/gcp/project.tf
+++ b/terraform/gcp/project.tf
@@ -16,6 +16,8 @@ module "wireguard" {
 
   activate_apis = [
     "cloudbilling.googleapis.com",
+    "compute.googleapis.com",
+    "iam.googleapis.com"
   ]
 
   # budget_alert_spent_percents = [0.7, 0.8, 0.9, 1.0]

--- a/terraform/gcp/providers.tf.example
+++ b/terraform/gcp/providers.tf.example
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+    google-beta = {
+      source = "hashicorp/google-beta"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "YOUR_BUCKET_NAME"
+    prefix = "terraform/wireguard-cloud-vpn"
+  }
+}

--- a/terraform/gcp/service_accounts.tf
+++ b/terraform/gcp/service_accounts.tf
@@ -1,0 +1,6 @@
+resource "google_service_account" "wireguard" {
+  account_id   = "wireguard"
+  display_name = "wireguard"
+  description  = "Service Account for the wireguard vpn instances."
+  project      = module.wireguard.project_id
+}

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -1,0 +1,72 @@
+# --------------------------------------------------
+# REQUIRED PARAMETERS
+# --------------------------------------------------
+variable "billing_account" {
+  description = "The ID of the billing account to associate this project with"
+  type        = string
+}
+
+variable "org_id" {
+  description = "The organization ID (can be blank)"
+  type        = string
+}
+
+# --------------------------------------------------
+# Project: Optional Parameters
+# --------------------------------------------------
+variable "project_name" {
+  description = "Project name to use"
+  type        = string
+  default     = "wireguard-cloud-vpn"
+}
+
+variable "project_id" {
+  description = "Project ID prefix to use"
+  type        = string
+  default     = "wireguard-cloud-vpn"
+}
+
+variable "labels" {
+  description = "Common labels to apply"
+  type        = map(any)
+  default     = {}
+}
+
+# --------------------------------------------------
+# Bucket: Optional Parameters
+# --------------------------------------------------
+variable "bucket_name" {
+  description = "Bucket name for git operations"
+  type        = string
+  default     = "gitops"
+}
+
+variable "bucket_location" {
+  description = "Region for the Bucket objects to be stored"
+  type        = string
+  default     = "US"
+}
+
+variable "bucket_storage_class" {
+  description = "Storage Class for the Bucket"
+  type        = string
+  default     = "MULTI_REGIONAL"
+}
+
+# --------------------------------------------------
+# VPN: Optional Parameters
+# --------------------------------------------------
+variable "subnet_flow_logs" {
+  type = object({
+    enabled  = bool
+    interval = string
+    sampling = number
+    metadata = string
+  })
+  default = {
+    enabled  = false
+    interval = "INTERVAL_30_SEC"
+    sampling = 0.8
+    metadata = "INCLUDE_ALL_METADATA"
+  }
+}

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -70,3 +70,82 @@ variable "subnet_flow_logs" {
     metadata = "INCLUDE_ALL_METADATA"
   }
 }
+
+# --------------------------------------------------
+# Instance Template: Optional Parameters
+# --------------------------------------------------
+variable "machine_type" {
+  description = "Machine type for compute instance"
+  type        = string
+  default     = "n1-standard-1"
+}
+
+variable "boot_disk_image_family" {
+  description = "Image family to use with boot disk"
+  type        = string
+  default     = "debian-10"
+}
+
+variable "boot_disk_image_project" {
+  description = "Project hosting the images"
+  type        = string
+  default     = "debian-cloud"
+}
+
+variable "boot_disk_size_gb" {
+  description = "Size (in GB) for the boot disk"
+  type        = number
+  default     = 20
+}
+
+variable "boot_disk_type" {
+  description = "Type of disk to use for boot"
+  type        = string
+  default     = "pd-ssd"
+}
+
+variable "boot_disk_auto_delete" {
+  description = "Auto-delete boot disk on destruction"
+  type        = bool
+  default     = true
+}
+
+variable "can_ip_forward" {
+  description = "Enable IP forwarding, i.e. NAT instances"
+  type        = bool
+  default     = true
+}
+
+variable "instance_labels" {
+  description = "Common labels to apply to instances"
+  type        = map(any)
+  default = {
+    env       = "production"
+    vpn       = true
+    exit_node = true
+  }
+}
+
+variable "instance_tags" {
+  description = "Network tags, provided as a list"
+  type        = list(string)
+  default = [
+    "iap-ssh"
+  ]
+}
+
+variable "service_account_scopes" {
+  description = "A list of service scopes for a service account"
+  type        = list(any)
+  default = [
+    "cloud-platform"
+  ]
+}
+
+variable "metadata" {
+  description = "Metadata configuration for instances"
+  type        = map(string)
+  default = {
+    enable-oslogin = "TRUE"
+  }
+}

--- a/terraform/gcp/vpn.tf
+++ b/terraform/gcp/vpn.tf
@@ -1,0 +1,50 @@
+locals {
+  network_name = "wg"
+
+  wireguard_subnets = [
+    {
+      subnet_name               = "gusw1-${local.network_name}"
+      subnet_ip                 = "10.0.0.0/30"
+      subnet_region             = "us-west1"
+      subnet_private_access     = "true"
+      subnet_flow_logs          = var.subnet_flow_logs.enabled
+      subnet_flow_logs_interval = var.subnet_flow_logs.interval
+      subnet_flow_logs_sampling = var.subnet_flow_logs.sampling
+      subnet_flow_logs_metadata = var.subnet_flow_logs.metadata
+    },
+    {
+      subnet_name               = "gusw2-${local.network_name}"
+      subnet_ip                 = "10.0.0.4/30"
+      subnet_region             = "us-west2"
+      subnet_private_access     = "true"
+      subnet_flow_logs          = var.subnet_flow_logs.enabled
+      subnet_flow_logs_interval = var.subnet_flow_logs.interval
+      subnet_flow_logs_sampling = var.subnet_flow_logs.sampling
+      subnet_flow_logs_metadata = var.subnet_flow_logs.metadata
+    },
+    {
+      subnet_name               = "gusw3-${local.network_name}"
+      subnet_ip                 = "10.0.0.8/30"
+      subnet_region             = "us-west2"
+      subnet_private_access     = "true"
+      subnet_flow_logs          = var.subnet_flow_logs.enabled
+      subnet_flow_logs_interval = var.subnet_flow_logs.interval
+      subnet_flow_logs_sampling = var.subnet_flow_logs.sampling
+      subnet_flow_logs_metadata = var.subnet_flow_logs.metadata
+    }
+  ]
+}
+
+# ----------------------------------------------------
+# Shared VPC for global VPN infrastructure
+# ----------------------------------------------------
+module "vpn" {
+  source  = "terraform-google-modules/network/google"
+  version = "3.1.2"
+
+  project_id      = module.wireguard.project_id
+  network_name    = local.network_name
+  shared_vpc_host = true
+  subnets         = local.wireguard_subnets
+}
+

--- a/terraform/gcp/vpn.tf
+++ b/terraform/gcp/vpn.tf
@@ -4,7 +4,7 @@ locals {
   wireguard_subnets = [
     {
       subnet_name               = "gusw1-${local.network_name}"
-      subnet_ip                 = "10.0.0.0/30"
+      subnet_ip                 = "10.0.0.0/29"
       subnet_region             = "us-west1"
       subnet_private_access     = "true"
       subnet_flow_logs          = var.subnet_flow_logs.enabled
@@ -14,7 +14,7 @@ locals {
     },
     {
       subnet_name               = "gusw2-${local.network_name}"
-      subnet_ip                 = "10.0.0.4/30"
+      subnet_ip                 = "10.0.0.8/29"
       subnet_region             = "us-west2"
       subnet_private_access     = "true"
       subnet_flow_logs          = var.subnet_flow_logs.enabled
@@ -24,8 +24,8 @@ locals {
     },
     {
       subnet_name               = "gusw3-${local.network_name}"
-      subnet_ip                 = "10.0.0.8/30"
-      subnet_region             = "us-west2"
+      subnet_ip                 = "10.0.0.16/29"
+      subnet_region             = "us-west3"
       subnet_private_access     = "true"
       subnet_flow_logs          = var.subnet_flow_logs.enabled
       subnet_flow_logs_interval = var.subnet_flow_logs.interval
@@ -42,9 +42,24 @@ module "vpn" {
   source  = "terraform-google-modules/network/google"
   version = "3.1.2"
 
-  project_id      = module.wireguard.project_id
-  network_name    = local.network_name
-  shared_vpc_host = true
-  subnets         = local.wireguard_subnets
+  project_id   = module.wireguard.project_id
+  network_name = local.network_name
+  subnets      = local.wireguard_subnets
 }
 
+# ----------------------------------------------------
+# Cloud Routers w/ NAT per subnet region
+# ----------------------------------------------------
+module "gusw1_router" {
+  source  = "terraform-google-modules/cloud-router/google"
+  version = "~> 0.4"
+
+  name    = "${local.network_name}-router-gusw1"
+  project = module.wireguard.project_id
+  region  = "us-west1"
+  network = module.vpn.network_name
+
+  nats = [{
+    name = "${local.network_name}-nat-gusw1"
+  }]
+}


### PR DESCRIPTION
Added the following:

1. Modified gitops to include versioning. This is important for Terraform state files
2. Added FW rule to allow IAP SSH to instances tagged `iap-ssh`
3. Added Compute Instance Template and Instance creator for `us-west1`
4. Added example `providers.tf` file for users
5. Created GCP Service Account for Compute Instance Template
6. Updated variables to include more defaults
7. Added VPC configuration with subnets, cloud router (only `gusw1`), and NAT for router (only `gusw1`)